### PR TITLE
Avoid unnecessary recompilation with two identically named files in sub folders

### DIFF
--- a/vunit/project.py
+++ b/vunit/project.py
@@ -10,7 +10,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 import hashlib
-from os.path import join, basename
+from os.path import join, basename, dirname
 
 from vunit.dependency_graph import DependencyGraph
 from vunit.vhdl_parser import VHDLDesignFile
@@ -310,7 +310,8 @@ class Project:
 
     def _hash_file_name_of(self, source_file):
         library = self.get_library(source_file.library.name)
-        return join(library.directory, basename(source_file.name) + ".vunit_hash")
+        md5_prefix = hashlib.md5(dirname(source_file.name).encode()).hexdigest()
+        return join(library.directory, md5_prefix, basename(source_file.name) + ".vunit_hash")
 
     def update(self, source_file):
         new_md5 = source_file.md5()

--- a/vunit/test/test_project.py
+++ b/vunit/test/test_project.py
@@ -218,7 +218,7 @@ end architecture;
 
         for file_name in ["file1.vhd", "file2.vhd", "file3.vhd"]:
             self.update(file_name)
-            self.assertIn(join("work_path", "%s.vunit_hash" % file_name), self.stub._files.keys())
+            self.assertIn(self.project._hash_file_name_of(self.get_source_file(file_name)), self.stub._files.keys())
 
     def test_should_not_recompile_updated_files(self):
         self.create_dummy_three_file_project()
@@ -272,7 +272,7 @@ end architecture;
         self.update("file3.vhd")
         self.assert_should_recompile([])
 
-        self.stub.remove_file(join("work_path", "file2.vhd.vunit_hash"))
+        self.stub.remove_file(self.project._hash_file_name_of(self.get_source_file("file2.vhd")))
         self.assert_should_recompile(["file2.vhd", "file3.vhd"])
 
     def create_dummy_three_file_project(self, update_file1=False):
@@ -325,6 +325,9 @@ end architecture;
     def add_source_file(self, library_name, file_name, contents):
         self.stub.write_file(file_name, contents)
         self.project.add_source_file(file_name, library_name)
+
+    def get_source_file(self, file_name):
+        return self.project._source_files[file_name]
 
     def update(self, file_name):
         self.project.update(self.project._source_files[file_name])

--- a/vunit/test/test_project.py
+++ b/vunit/test/test_project.py
@@ -120,6 +120,21 @@ end entity;
         self.update("foo1_ent.vhd")
         self.assert_should_recompile(["foo_arch.vhd"])
         
+    def test_multiple_identical_file_names_with_different_path_in_same_library(self):
+        self.project.add_library("lib", "lib_path")
+        self.add_source_file("lib", join("a", "foo.vhd"), """
+entity a_foo is
+end entity;
+""")
+
+        self.add_source_file("lib", join("b", "foo.vhd"), """
+entity b_foo is
+end entity;
+""")
+        self.assert_should_recompile([join("a", "foo.vhd"), join("b", "foo.vhd")])
+        self.update(join("a", "foo.vhd"))
+        self.update(join("b", "foo.vhd"))
+        self.assert_should_recompile([])
 
     def test_finds_entity_architecture_dependencies(self):
         self.project.add_library("lib", "lib_path")


### PR DESCRIPTION
If a/foo.vhd and b/foo.vhd are added to the same library one of them will always be recompiled since their vunit_hash-files collide.

This is a problem when using vunit in a Microsemi environment since all generated FIFO IP-cores are supposed to be in the same library and each FIFO contains identically named vhd-files. 

