### PR TITLE
Remove tcl flag. Closes #16 for Microsemi 10.3a

### DIFF
--- a/vunit/modelsim_interface.py
+++ b/vunit/modelsim_interface.py
@@ -135,8 +135,11 @@ proc vunit_load {{}} {{
     {set_generic_str}
 
     # Workaround -modelsimini flag not respected in some versions of modelsim
-    global env
-    set env(MODELSIM) "{modelsimini}"
+    # however, Microsemi 10.3a corrupts the enviromnent variable (see dvt64978)
+    if {{[string first "Microsemi vsim 10.3a" [vsimVersionString]] eq -1}} {{
+        global env
+        set env(MODELSIM) "{modelsimini}"
+    }}
     vsim -wlf "{wlf_file_name}" -quiet -t ps {pli_str} {set_generic_name_str} {library_name}.{entity_name}{architecture_suffix}
     set no_finished_signal [catch {{examine -internal {{/vunit_finished}}}}]
     set no_test_runner_exit [catch {{examine -internal {{/run_base_pkg/runner.exit_without_errors}}}}]


### PR DESCRIPTION
The fix (0bcfe8f26587) does not remove the MODELSIM flag from the tcl scripts.
With Microsemi 10.3a this leads to MODELSIM being unset instead of correctly set from the init()-call.