### PR TITLE
Removed references to std_logic_unsigned.

### DIFF
--- a/vhdl/check/src/check.vhd
+++ b/vhdl/check/src/check.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use ieee.numeric_std.all;
 use std.textio.all;
 use work.check_types_pkg.all;

--- a/vhdl/check/src/check_base.vhd
+++ b/vhdl/check/src/check_base.vhd
@@ -9,7 +9,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.check_types_pkg.all;
 use work.log_base_pkg.all;

--- a/vhdl/check/src/check_base93.vhd
+++ b/vhdl/check/src/check_base93.vhd
@@ -9,7 +9,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.check_types_pkg.all;
 use work.log_base_pkg.all;

--- a/vhdl/check/src/check_base_api.vhd
+++ b/vhdl/check/src/check_base_api.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.check_types_pkg.all;
 use work.check_special_types_pkg.all;

--- a/vhdl/check/src/check_special_types200x.vhd
+++ b/vhdl/check/src/check_special_types200x.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.log_types_pkg.all;
 use work.log_special_types_pkg.all;

--- a/vhdl/check/src/check_special_types93.vhd
+++ b/vhdl/check/src/check_special_types93.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.log_types_pkg.all;
 use work.log_special_types_pkg.all;

--- a/vhdl/check/src/check_types.vhd
+++ b/vhdl/check/src/check_types.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.log_types_pkg.all;
 use work.log_special_types_pkg.all;

--- a/vhdl/logging/src/log.vhd
+++ b/vhdl/logging/src/log.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.log_base_pkg.all;
 

--- a/vhdl/logging/src/log_base.vhd
+++ b/vhdl/logging/src/log_base.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use work.log_types_pkg.all;
 
 package body log_base_pkg is

--- a/vhdl/logging/src/log_base93.vhd
+++ b/vhdl/logging/src/log_base93.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.lang.all;
 use work.string_ops.all;

--- a/vhdl/logging/src/log_base93_mock.vhd
+++ b/vhdl/logging/src/log_base93_mock.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.lang.all;
 use work.string_ops.all;

--- a/vhdl/logging/src/log_base_api.vhd
+++ b/vhdl/logging/src/log_base_api.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.textio.all;
 use work.log_types_pkg.all;

--- a/vhdl/logging/src/log_base_api_mock.vhd
+++ b/vhdl/logging/src/log_base_api_mock.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.textio.all;
 use work.log_types_pkg.all;

--- a/vhdl/logging/src/log_special_types200x.vhd
+++ b/vhdl/logging/src/log_special_types200x.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.lang.all;
 use work.textio.all;

--- a/vhdl/logging/src/log_special_types200x_mock.vhd
+++ b/vhdl/logging/src/log_special_types200x_mock.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.lang.all;
 use work.textio.all;

--- a/vhdl/logging/src/log_special_types93.vhd
+++ b/vhdl/logging/src/log_special_types93.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.log_types_pkg.all;
 

--- a/vhdl/logging/src/log_types.vhd
+++ b/vhdl/logging/src/log_types.vhd
@@ -8,7 +8,6 @@
 
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.std_logic_unsigned.all;
 use std.textio.all;
 use work.lang.all;
 use work.textio.all;


### PR DESCRIPTION
I've removed references to std_logic_unsigned.
    
This library is not officially standardized and has known problems. This library does not really use std_logic_unsigned, so safe to remove.