### PR TITLE
tells the destinaton of the compilation

### DIFF
--- a/vunit/modelsim_interface.py
+++ b/vunit/modelsim_interface.py
@@ -147,7 +147,7 @@ class ModelSimInterface(object):
             self.create_library(library.name, library.directory, mapped_libraries)
 
         for source_file in project.get_files_in_compile_order():
-            print('Compiling ' + source_file.name + ' ...')
+            print('Compiling ' + source_file.name + ' into ' + source_file.library.name + ' ...')
 
             if source_file.file_type == 'vhdl':
                 success = self.compile_vhdl_file(source_file.name, source_file.library.name, vhdl_standard)


### PR DESCRIPTION
A small one.  Before VUnit, we had one Makefile for every library.  Now, it's all in one run.py script.  And without this small modification it was hard to find out from the logging into which library the VHDL was compiled into.