### PR TITLE
Example of dependency generation

### DIFF
--- a/examples/vhdl/compile_order/compile_order.vhd
+++ b/examples/vhdl/compile_order/compile_order.vhd
@@ -1,0 +1,12 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2015, Lars Asplund lars.anders.asplund@gmail.com
+
+entity compile_order is
+end entity compile_order;
+
+architecture compile_order_arch of compile_order is
+begin
+end architecture compile_order_arch;

--- a/examples/vhdl/compile_order/compile_order_top.vhd
+++ b/examples/vhdl/compile_order/compile_order_top.vhd
@@ -1,0 +1,13 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2015, Lars Asplund lars.anders.asplund@gmail.com
+
+entity compile_order_top is
+end entity compile_order_top;
+
+architecture compile_order_top_arch of compile_order_top is
+begin
+	compile_order_inst : entity work.compile_order;
+end architecture compile_order_top_arch;

--- a/examples/vhdl/compile_order/run.py
+++ b/examples/vhdl/compile_order/run.py
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2014-2015, Lars Asplund lars.anders.asplund@gmail.com
+
+# Example of how you can extract compilation order using VUnit
+# Note that you cannot run VUnit normally via this script
+
+from os.path import join, dirname
+from vunit import VUnit
+
+root = dirname(__file__)
+
+ui = VUnit.from_argv()
+lib = ui.add_library("lib")
+lib.add_source_files(join(root, "*.vhd"))
+source_files = ui.get_project_compile_order_dependents(target=join(root, "compile_order_top.vhd"))
+
+for source_file in source_files:
+    print(source_file.library.name + ", " + source_file.name + '\n')

--- a/vunit/dependency_graph.py
+++ b/vunit/dependency_graph.py
@@ -94,4 +94,4 @@ class DependencyGraph(object):
         return dependencies
 
     def get_dependencies(self, node):
-        return self._backward.get(node, [])
+        return self._backward.get(node, set())

--- a/vunit/project.py
+++ b/vunit/project.py
@@ -212,6 +212,29 @@ class Project(object):
             return compile_order.index(source_file)
 
         return sorted(affected_files, key=comparison_key)
+    
+    def get_dependencies_in_compile_order(self, target):
+        """
+        Get a list of dependencies of target, if target is specified.
+        Otherwise, get a list of all files in the project.
+        The files will be listed in compile order.
+        target -- absolute or relative path to a file
+        """
+        dependency_graph = self._create_dependency_graph()
+        if target is None:
+            sorted_files = self.get_files_in_compile_order(incremental=False)
+        else:
+            target_file = self._source_files[target]
+    
+            affected_files = dependency_graph.get_dependencies(target_file)
+            affected_files.add(target_file)
+            compile_order = dependency_graph.toposort()
+
+            def comparison_key(source_file):
+                return compile_order.index(source_file)
+            
+            sorted_files = sorted(affected_files, key=comparison_key)
+        return sorted_files
 
     def get_source_files_in_order(self):
         """

--- a/vunit/test/unit/test_dependency_graph.py
+++ b/vunit/test/unit/test_dependency_graph.py
@@ -61,6 +61,25 @@ class TestDependencyGraph(unittest.TestCase):
         graph.add_dependency('b', 'g')
         result = graph.toposort()
         self._check_result(result, dependencies)
+    
+    def test_get_dependencies_should_return_empty_set_when_no_dependendencies(self):
+        nodes = ['a', 'b', 'c']
+        dependencies = []
+        graph = DependencyGraph()
+        self._add_nodes_and_dependencies(graph, nodes, dependencies)
+        result = graph.get_dependencies('b')
+        self.assertTrue(isinstance(result, (set)))
+        self.assertFalse(result)
+        
+    def test_get_dependencies_should_return_dependendencies_set(self):
+        nodes = ['a', 'b', 'c', 'd']
+        dependencies = [('a', 'b'), ('a', 'c')]
+        graph = DependencyGraph()
+        self._add_nodes_and_dependencies(graph, nodes, dependencies)
+        result = graph.get_dependencies('c')
+        print result
+        self.assertFalse('b' in result)
+        self.assertTrue('a' in result)
 
     def _check_result(self, result, dependencies):
         """

--- a/vunit/test/unit/test_project.py
+++ b/vunit/test/unit/test_project.py
@@ -449,6 +449,21 @@ end architecture;
         self.assert_compiles("comp1.vhd", before="top.vhd")
         self.assert_compiles("comp2.vhd", before="top.vhd")
 
+    def test_get_dependencies_in_compile_order_without_target(self):
+        self.create_dummy_three_file_project(False)
+        deps = self.project.get_dependencies_in_compile_order(target=None)
+        self.assertEqual(len(deps), 3)
+        self.assertTrue(deps[0] == self.project.get_source_files_in_order()[0])
+        self.assertTrue(deps[1] == self.project.get_source_files_in_order()[1])
+        self.assertTrue(deps[2] == self.project.get_source_files_in_order()[2])
+
+    def test_get_dependencies_in_compile_order_with_target(self):
+        self.create_dummy_three_file_project(False)
+        deps = self.project.get_dependencies_in_compile_order(target=self.project.get_source_files_in_order()[1].name)
+        self.assertEqual(len(deps), 2)
+        self.assertTrue(deps[0] == self.project.get_source_files_in_order()[0])
+        self.assertTrue(deps[1] == self.project.get_source_files_in_order()[1])
+        
     def create_dummy_three_file_project(self, update_file1=False):
         """
         Create a projected containing three dummy files

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -473,6 +473,14 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
             library = self.library(library_name)
         add_osvvm(library)
 
+    def get_project_compile_order_dependents(self, target=None):
+        """
+        Get list of all source files on which target depends, including
+        itself, in compilation order if target is specified. Otherwise,
+        return a list of all project files in compile order.  
+        """
+        return self._project.get_dependencies_in_compile_order(target=abspath(target))
+
 
 class LibraryFacade(object):
     """


### PR DESCRIPTION
Here is an implementation that I think is close to what we were discussing earlier in issue #67. I am (still) not 100% sold on how to roll this functionality into the public interface of VUnit. You can see what I did below as an example. I created a trivial example as well.

While I was working on this, I think I also found a minor bug in the dependency_graph.py. An edge case if there were no dependencies to return. Check it out.