### PR TITLE
Allow HDL files with various case extensions (upper, lower, mixed)

### DIFF
--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 import sys
 import os
 import traceback
+import string
 
 from os.path import exists, abspath, join, basename, splitext
 from glob import glob
@@ -42,6 +43,10 @@ from vunit.com import codec_generator
 
 import logging
 LOGGER = logging.getLogger(__name__)
+
+# lower case representation of supported extensions
+VHDL_EXTENSIONS = (".vhd", ".vhdl")
+VERILOG_EXTENSIONS = (".v", ".vp", ".sv")
 
 
 class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-public-methods
@@ -665,9 +670,9 @@ def file_type_of(file_name):
     Return the file type of file_name based on the file ending
     """
     _, ext = splitext(file_name)
-    if ext in (".vhd", ".vhdl"):
+    if string.lower(ext) in VHDL_EXTENSIONS:
         return "vhdl"
-    elif ext in (".v", ".vp", ".sv"):
+    elif string.lower(ext) in VERILOG_EXTENSIONS:
         return "verilog"
     else:
         raise RuntimeError("Unknown file ending '%s' of %s" % (ext, file_name))


### PR DESCRIPTION
I have run into a problem using VUnit where some of the files are using different cases than directly supported. For example, *.VHD instead of .vhd, or more horrifically, .VHDL  (who does this?)

Unfortunately, it is not as easy as renaming the file. Some CM tools (e.g. Perforce) when hosted on a server that is case insensitive (e.g. Windows) does not allow changing the case. However the file was first checked in will be how it will forever stay. Sure, you can change it in your local workspace, but next time you checkout a fresh copy... bad news.

This fix simply forces the extension compatibility check to use a lower case representation of the input file extension. This should allow any case of extensions to be supported.

I wasn't sure how you may want to refactor the extensions out from being hard-coded in a function, so I took a stab.

I couldn't find any other cases where the case may matter, but I may have missed somewhere.
I added a couple unittest cases to check for various capitalization. I also added a testcase for a "bad" file extension. I am not sure if this was covered somewhere else already, but I figured it can't hurt.