### PR TITLE
Improved performance of removing comments from code

### DIFF
--- a/vunit/vhdl_parser.py
+++ b/vunit/vhdl_parser.py
@@ -912,10 +912,4 @@ def remove_comments(code):
     """
     Return the code with comments removed
     """
-    new_code = ''
-    lines = code.split('\n')
-    for line in lines:
-        line_wo_comments = line.split('--')[0] + '\n'
-        new_code = new_code + line_wo_comments
-
-    return new_code
+    return re.sub(r'--[^\n]*', '', code)


### PR DESCRIPTION
I have found that the new implementation can remove comments from a buffer in approximately 1/3 or 1/4 of the original implementation time for very large HDL files. For small files it is similarly efficient, but not slower in my testing. This is based on discussion at: http://codereview.stackexchange.com/questions/102689/efficiently-concatenate-substrings-of-long-list-of-strings

I discovered this was originally an issue when attempting to work with very large HDL files, which had been machine generated (i.e. Xilinx CoreGen / IP generator), and were extremely long files. This still might solve the problem completely, but it should speed things up considerably.

Here are the results, based on testing with Python 2.7.9:

For a very large file (200k lines):
```
original_function function; best of 100: 165.227 ms; avg: 174.625
rc1 function; best of 100: 129.164 ms; avg: 135.549
rc2 function; best of 100: 91.791 ms; avg: 98.802
rc3 function; best of 100: 43.703 ms; avg: 49.473
rc4 function; best of 100: 103.761 ms; avg: 110.493
rc5 function; best of 100: 44.390 ms; avg: 50.734
```

For a small file (25 lines):
```
original_function function; best of 100: 0.037 ms; avg: 0.139
rc1 function; best of 100: 0.038 ms; avg: 0.124
rc2 function; best of 100: 0.067 ms; avg: 0.139
rc3 function; best of 100: 0.026 ms; avg: 0.123
rc4 function; best of 100: 0.054 ms; avg: 0.179
rc5 function; best of 100: 0.031 ms; avg: 0.118
```

The implementation of `rc3` is the suggested implementation of this pull request.