### PR TITLE
adding the hostname where the test where executed to the JUnit XML te…

### DIFF
--- a/vunit/test_report.py
+++ b/vunit/test_report.py
@@ -13,6 +13,7 @@ from vunit.color_printer import COLOR_PRINTER
 from xml.etree import ElementTree
 from sys import version_info
 import os
+import socket
 
 
 class TestReport(object):
@@ -177,6 +178,7 @@ class TestReport(object):
         root.attrib["failures"] = str(len(failures))
         root.attrib["skipped"] = str(len(skipped))
         root.attrib["tests"] = str(len(self._test_results))
+        root.attrib["hostname"] = socket.gethostname()
 
         for result in self._test_results_in_order():
             root.append(result.to_xml())


### PR DESCRIPTION
…st report.

I was looking for a way to include the description of a test to the JUnit XML format.  It seems to be not existing in the XSD of JUnit.
Anyhow, this is a small change to keep track of the computer server where the tests where running on.